### PR TITLE
chore: remove shebang

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { exec, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';


### PR DESCRIPTION
Due to it, GitHub was misclassifying this repo as JavaScript instead of TypeScript.