### PR TITLE
Fix installation regression & stop supporting args to launcher script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ if [ \${#EXPOSED_DIRS[@]} -gt 0 ]; then
 fi
 
 echo "Launching pi-coding-agent with ${AGENT_USER} user (sudo is required to impersonate '${AGENT_USER}' user)..."
-exec sudo -i -u ${AGENT_USER} bash -c 'export npm_config_prefix=$PI_HOME/.npm-global && mkdir -p ${workDir} && cd ${workDir} && ${installDir}/node_modules/.bin/pi "$@"' -- "$@"
+exec sudo -i -u ${AGENT_USER} bash -c 'export npm_config_prefix=$PI_HOME/.npm-global && mkdir -p ${workDir} && cd ${workDir} && ${installDir}/node_modules/.bin/pi'
 `;
   fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
   console.log('Launcher script created.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ if [ \${#EXPOSED_DIRS[@]} -gt 0 ]; then
 fi
 
 echo "Launching pi-coding-agent with ${AGENT_USER} user (sudo is required to impersonate '${AGENT_USER}' user)..."
-exec sudo -i -u ${AGENT_USER} bash -c 'export npm_config_prefix=$PI_HOME/.npm-global && mkdir -p ${workDir} && cd ${workDir} && ${installDir}/node_modules/.bin/pi'
+exec sudo -i -u ${AGENT_USER} bash -c "export npm_config_prefix=$PI_HOME/.npm-global && mkdir -p ${workDir} && cd ${workDir} && ${installDir}/node_modules/.bin/pi"
 `;
   fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
   console.log('Launcher script created.');


### PR DESCRIPTION
$PI_HOME was not being expanded properly (because it missed double
quotes instead of single-quotes) and caused:

```
Installing @mariozechner/pi-coding-agent into /Users/pi/pi...
Package installed.
pi's PATH already configured in .zshrc, skipping.
Creating launcher script at /Users/knocte/bin/pi...
Launcher script created.
$HOME/bin already in PATH (.zshrc).
About to launch pi-coding-agent...
NOTE: /Users/Shared is world-accessible. This is a macOS default, but you may want to restrict it manually if it contains sensitive data.
Press any key to continue...
Launching pi-coding-agent with pi user (sudo is required to impersonate 'pi' user)...
Password:
npm error code ENOENT
npm error syscall mkdir
npm error path /.npm-global
npm error errno -2
npm error enoent ENOENT: no such file or directory, mkdir '/.npm-global'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: /Users/pi/.npm/_logs/2026-04-14T11_19_15_656Z-debug-0.log
file:///Users/pi/pi/node_modules/@mariozechner/pi-coding-agent/dist/core/package-manager.js:1812
                    reject(new Error(`${command} ${args.join(" ")} failed with code ${code}`));
                           ^

Error: npm install -g awto-pi-lot failed with code 254
    at ChildProcess.<anonymous> (file:///Users/pi/pi/node_modules/@mariozechner/pi-coding-agent/dist/core/package-manager.js:1812:28)
    at ChildProcess.emit (node:events:509:20)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)

Node.js v25.9.0
Error: Error: pi-coding-agent exited with code 1
    at ChildProcess.<anonymous> (/Users/knocte/Documents/Code/skynot/dist/index.js:355:24)
    at ChildProcess.emit (node:events:509:20)
    at maybeClose (node:internal/child_process:1108:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

This bug was introduced in:
https://github.com/nblockchain/skynot/pull/6

Also stop supporting args to launcher script: we can explore them in the future;
for now we just support interactive sessions.