### PR TITLE
Change launcher script name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const execAsync = promisify(exec);
 
 const AGENT_PACKAGE = '@mariozechner/pi-coding-agent';
 const AGENT_USER = 'pi';
-const LAUNCHER_SCRIPT_FILENAME = 'pi';
+const LAUNCHER_SCRIPT_FILENAME = 'spi';
 const AGENT_GROUP_NAME = "aiteam";
 
 function getShellRcFile(): string {


### PR DESCRIPTION
BREAKING CHANGE: launcher script name is now changed from 'pi' to 'spi' so that people that already have Pi installed can try skynot without affecting their current workflows.