### PR TITLE
Support passing args to launcher script

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -50,6 +50,7 @@ The following command‑line flags are available:
 |`--help`      | `-h`   | Show the help message with all available options.                                 |
 |`--auth`      | `-a`   | Ask about auth details (provider name and API key) to add it to launcher script.  |
 |`--extensions`| `-e`   | After installing Pi, also install recommended extensions.                         |
+|              |        | NOTE: for custom extensions, just launch `spi install <extension>` after install. |
 |`--npm`       | `-n`   | Install Pi using npm instead of tarball (likely to be slower though).             |
 |`--paranoid`  | `-p`   | Never cache the sudo password; ask for it every time it is needed.                |
 |`--ssh`       | `-s`   | Copy SSH keys to the `aidev` user for git+ssh (& add GitHub to `known_hosts`).    |

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,8 +423,9 @@ if [ \${#EXPOSED_DIRS[@]} -gt 0 ]; then
   echo ""
 fi
 
+FULL_SUDO_CMD="export npm_config_prefix=$AGENT_USER_HOME/.npm-global && cd $CURRENT_DIR && ${piBinaryPath} $@"
 echo "Launching Pi with ${AGENT_USER} user (sudo is required to impersonate '${AGENT_USER}' user)..."
-exec sudo -i -u ${AGENT_USER} bash -c "export npm_config_prefix=$AGENT_USER_HOME/.npm-global && cd $CURRENT_DIR && ${piBinaryPath}"
+exec sudo -i -u ${AGENT_USER} bash -c "$FULL_SUDO_CMD"
 `;
   fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
   console.log('Launcher script created.');


### PR DESCRIPTION
This way, if you forgot to use -e to install extensions (or the recommended extensions are not enough ;) ) then you can install extensions after the fact.

This partially reverts this commit [1] but explicitly performs the $@ interpolation in an earlier variable that gets declared before launching bash, otherwise only the 1st param ("install"), but not the second (the extension name), would be passed (likely because of similar reasons to the ones explained in [2]).

[1] 17b9b11cc12d2f112949d1cba48ebb041716818b
[2] https://superuser.com/a/1601876