### PR TITLE
CI: use container-based approach

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,18 +21,19 @@ concurrency:
 jobs:
   build-check:
     runs-on: ubuntu-latest
+    container:
+      image: 'ubuntu:26.04'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Update system dependencies
         run: |
-          sudo apt-get update
+          apt update --yes
+
+      - name: Install system dependencies
+        run: |
+          apt install --yes npm
 
       - name: Install dependencies
         run: npm install

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -66,3 +66,10 @@ Please note, `-u` would technically not wipe or reinstall extensions, as they no
 
 - The script runs many operations as the `aidev` user via `sudo`. It sets `npm_config_prefix` to `$HOME/.npm-global` to avoid permission errors when installing extensions from NPM.
 - To test locally (directly from sources instead of using `npx`), use `npm run exec -- [options]` (e.g. `npm run exec -- -e`).
+
+
+## Requirements
+
+* Linux or macOS
+* NodeJS v22.x
+* NPM's `npx` (install with `brew install npm` or `apt install npm`)


### PR DESCRIPTION
This way CI is not a black box (you can see how to install Node from a vanilla ubuntu OS).