### PR TITLE
Pin Pi to v0.70.5 because v0.70.6 has a regression

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,7 @@ async function installAgentFromTarball(verbose?: boolean): Promise<void> {
 
     console.log(`Installing ${tarballName} into ${piInstallDir}...`);
 
-    const releasesUrl = `https://api.github.com/repos/${AGENT_GITHUB_REPO}/releases/latest`;
+    const releasesUrl = `https://api.github.com/repos/${AGENT_GITHUB_REPO}/releases/tags/v0.70.5`;
     const response = await fetch(releasesUrl);
     if (!response.ok) {
         throw new Error(`Error when getting releases: ${response.status}`);


### PR DESCRIPTION
Looks like it could have been caused by upstream PR3861.