### PR TITLE
Fix invokation via `npx`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 dist/
 node_modules/
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Installer for pi-coding-agent embedded as a simple NPX tool to set up a user named `aidev`, and download Pi inside its $HOME (launcher script will be called `spi` instead of `pi`)",
   "main": "dist/index.js",
   "bin": {
-    "skynot": "dist/index.js"
+    "skynot": "bin/skynot"
   },
   "scripts": {
     "build": "npm install && npx tsc",


### PR DESCRIPTION
These past days/weeks I had just been testing skynot via `npm run exec` and was working fine. Today I realised that calling it via `npx` was actually broken because it gave this error:

```

/Users/knocte/.npm/_npx/e5966479decd172a/node_modules/.bin/skynot: line 1: use strict: command not found
/Users/knocte/.npm/_npx/e5966479decd172a/node_modules/.bin/skynot: line 2: syntax error near unexpected token `('
/Users/knocte/.npm/_npx/e5966479decd172a/node_modules/.bin/skynot: line 2: `var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {'
```

My clanker fixed it right away, this was the summary:

---

What was happening

 package.json declared the binary like this:

 ```json
   "bin": {
     "skynot": "dist/index.js"
   }
 ```

 dist/index.js is a plain compiled JavaScript file without a shebang.
 When npm (and therefore npx) creates the wrapper in node_modules/.bin/skynot, it simply copies the target file.
 So the wrapper ends up being the contents of dist/index.js itself:

 ```bash
   "use strict";
   var __createBinding = (this && this.__createBinding) || …
 ```

 When the wrapper is executed by the shell, the first line ("use strict";) is interpreted as a command, which yields the error you saw:

 ```
   line 1: use strict: command not found
   line 2: syntax error near unexpected token `('
 ```

 Running the tool via npm run exec works because you explicitly invoke node dist/index.js, bypassing the broken wrapper.

 ────────────────────────────────────────────────────────────────────────────────

 How we fixed it

 1. Add a proper executable script that launches the compiled entry point: File created: bin/skynot ```bash #!/usr/bin/env node require('../dist/index.js'); ``` The script has a shebang (#!/usr/bin/env node) so the OS knows to run it with Node, and it simply requires the compiled file.
 2. Update the bin field in package.json to point to this script instead of the raw compiled file: ```json "bin": { "skynot": "bin/skynot" }, ``` This ensures that both npm install‑based execution and npx will receive a proper executable wrapper.
 3. Make the new script executable (the chmod +x bin/skynot step is only needed locally; when the package is published the file will retain its executable flag).

 ────────────────────────────────────────────────────────────────────────────────

 Result

 - Running locally with npm run exec still works (it builds then runs node dist/index.js).
 - Running via npx skynot now executes the correctly‑shebanged wrapper, which in turn loads dist/index.js. The previous “use strict: command not found” errors disappear.

 You can verify it locally:

 ```bash
   npm run build                 # rebuild dist/
   chmod +x bin/skynot           # make sure the script is executable
   ./bin/skynot                  # works (same output as npm run exec)
 ```

 When the package is published, npx skynot will use the same bin/skynot entry and function correctly.