### PR TITLE
feat: pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "homepage": "https://github.com/tarsgate/skynot#readme",
   "dependencies": {
-    "fp-sdk": "^0.1.2",
-    "commander": "^11.0.0"
+    "fp-sdk": "0.1.2",
+    "commander": "11.0.0"
   },
   "devDependencies": {
     "prettier": "2.8.3",
-    "@types/node": "^20.12.0",
-    "typescript": "^5.3.3"
+    "@types/node": "20.12.0",
+    "typescript": "5.3.3"
   }
 }


### PR DESCRIPTION
I've been a long proponent of not updating deps for update sake, and even if I have refused to use dependabot for long time, this is not enough in the NPM ecosystem because deps can still be updated by your users due to this dreadful ^ character next to the version number of your dependency.

Now, in this climate of constant supply-chain attacks, finally decent devs from the industry are starting to speak up about this shit[1] and also taking action[2], so I'll follow suit.

[1] https://x.com/mitchellh/status/2057171518027887035
[2] https://github.com/earendil-works/pi/commit/2e02c74dcb9787e3feca7fad67082faed4a1b3cd