### PR TITLE
CI: improve publish job to gen GH release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
 
       # CRITICAL for provenance
       id-token: write
@@ -58,7 +58,48 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Generate Changelog
+        run: |
+          npx --package conventional-changelog-cli conventional-changelog --preset angular --release-count 1 > CHANGELOG_RELEASE.md
+          cat CHANGELOG_RELEASE.md
+
+      - name: Verify CHANGELOG.md matches
+        run: |
+          # Verify that the generated CHANGELOG_RELEASE.md block matches what we expect
+          echo "Comparing release notes..."
+          # Since the commit has been tagged, CHANGELOG.md should already contain the latest release notes at the top.
+          # Let's verify that the generated release notes match the top of CHANGELOG.md.
+          # Since CHANGELOG.md has headers and compare links, a simple check can verify if CHANGELOG_RELEASE.md content is a prefix of CHANGELOG.md.
+          # Or, the release script can write the exact release notes to a specific file or we can compare them.
+          # Let's keep it simple: we can check if CHANGELOG_RELEASE.md is a sub-string or at the start of CHANGELOG.md.
+          # To be very robust:
+          head -n "$(wc --lines < CHANGELOG_RELEASE.md)" CHANGELOG.md > CHANGELOG_TOP.md
+          if ! diff -q CHANGELOG_RELEASE.md CHANGELOG_TOP.md >/dev/null; then
+            echo "ERROR: CHANGELOG.md does not have the expected release notes at the top!"
+            echo "Expected:"
+            cat CHANGELOG_RELEASE.md
+            echo "But got at the top of CHANGELOG.md:"
+            cat CHANGELOG_TOP.md
+            exit 1
+          fi
+          echo "✓ CHANGELOG.md verified!"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ env.HEAD_TAG }}" \
+            --title "${{ env.HEAD_TAG }}" \
+            --notes-file CHANGELOG_RELEASE.md
+
       - name: Publish skynot to npm
-        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! npm publish --provenance --access public; then
+            echo "NPM publish failed! Rolling back GitHub release..."
+            gh release delete "${{ env.HEAD_TAG }}" --yes || true
+            exit 1
+          fi
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make sure we are on master branch and up to date
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "master" ]; then
+    echo "ERROR: You must be on the 'master' branch to release (current: '$CURRENT_BRANCH')." >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: Working directory is not clean. Commit or stash your changes first." >&2
+    exit 1
+fi
+
+# Dry-run generation of the release notes for the next version
+echo "Generating preview of conventional changelog for next release..."
+
+# Get version from package.json
+PKG_VERSION=$(node -p "require('./package.json').version")
+NEXT_TAG="v$PKG_VERSION"
+
+if git rev-parse "$NEXT_TAG" >/dev/null 2>&1; then
+    echo "ERROR: Tag $NEXT_TAG already exists in git! Did you forget to bump version in package.json?" >&2
+    exit 1
+fi
+
+# We temporarily tag the HEAD to let conventional-changelog generate the correct comparison links and headers
+git tag "$NEXT_TAG"
+
+# Generate releasing changelog
+TEMP_CHANGELOG=$(mktemp)
+npx --package conventional-changelog-cli conventional-changelog --preset angular --release-count 1 > "$TEMP_CHANGELOG"
+
+# Clean up temporary tag so we don't leave things messy if aborted
+git tag -d "$NEXT_TAG"
+
+echo "--------------------------------------------------"
+cat "$TEMP_CHANGELOG"
+echo "--------------------------------------------------"
+
+echo "Press any key to approve these release notes, write them to CHANGELOG.md, and commit/tag/push... (or Ctrl+C to abort)"
+read -r -n 1 -s
+
+# Create CHANGELOG.md if it doesn't exist
+if [ ! -f CHANGELOG.md ]; then
+    touch CHANGELOG.md
+fi
+
+# Prepend the new release notes to CHANGELOG.md
+TEMP_FILE=$(mktemp)
+cat "$TEMP_CHANGELOG" CHANGELOG.md > "$TEMP_FILE"
+mv "$TEMP_FILE" CHANGELOG.md
+
+# Clean up temp changelog file
+rm "$TEMP_CHANGELOG"
+
+# Format CHANGELOG.md if needed
+if [ -f node_modules/.bin/prettier ] || [ -f package.json ]; then
+    npm run format || true
+fi
+
+# Commit CHANGELOG.md and package.json version bump
+git add CHANGELOG.md package.json
+git commit -m "chore: release $NEXT_TAG"
+
+# Tag the release commit
+git tag "$NEXT_TAG"
+
+# Push to origin
+echo "Pushing commits and tags to origin..."
+git push origin master
+git push origin "$NEXT_TAG"
+
+echo "Success! Release $NEXT_TAG pushed successfully."


### PR DESCRIPTION
Assisted by a scripts/release.sh job though.

NB: The angular preset was chosen for a few practical reasons:
* Perfect Compatibility: It is the original, de facto standard for conventional-changelog and handles scope conventions perfectly (e.g., matching the feat, fix, chore, refactor pattern in your commit history).
* Explicit Mentions in CLI/Documentation: It's one of the most widely supported and natively built presets, which ensures that it works out of the box without needing extra configuration files or additional npm dependency packages (like peer dependencies that some other presets require).
* Clean Output: It groups changes cleanly into readable categories (e.g., Bug Fixes, Features) and automatically appends nice comparison links and Git commit hash references.