### PR TITLE
CI: really include ChangeLog via gh rel edit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           # Since package.json already has the target version and we are on the tag commit,
           # conventional-changelog correctly detects the latest tag and generates exactly 1 release
           # from the previous tag up to this current one.
-          npx --package conventional-changelog-cli conventional-changelog --preset angular --release-count 1 > CHANGELOG_RELEASE.md
+          NODE_OPTIONS="--import tsx" npx --no-install conventional-changelog --config changelog.config.ts --release-count 1 > CHANGELOG_RELEASE.md
           cat CHANGELOG_RELEASE.md
 
       - name: Verify CHANGELOG.md matches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,9 @@ jobs:
         run: |
           gh release create "${{ env.HEAD_TAG }}" \
             --title "${{ env.HEAD_TAG }}" \
+            --notes-file CHANGELOG_RELEASE.md || \
+          gh release edit "${{ env.HEAD_TAG }}" \
+            --title "${{ env.HEAD_TAG }}" \
             --notes-file CHANGELOG_RELEASE.md
 
       - name: Publish skynot to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## [0.0.755](https://github.com/tarsgate/skynot/compare/v0.0.753...v0.0.755) (2026-05-27)
 
+### Improvements
 
-### Bug Fixes
-
-* **macOS:** more group names to ignore list ([bbf5e20](https://github.com/tarsgate/skynot/commit/bbf5e207e0e5c0076b32360ce87aba474834c655))
-* **macOS:** stop trying to rm from 'everyone' grp ([1b22321](https://github.com/tarsgate/skynot/commit/1b22321f233853c1782b2a7e5bdcddff4c78ebd8))
+* **macOS:** stop trying to remove from default macOS groups ([1b22321](https://github.com/tarsgate/skynot/commit/1b22321f233853c1782b2a7e5bdcddff4c78ebd8)) , ([bbf5e20](https://github.com/tarsgate/skynot/commit/bbf5e207e0e5c0076b32360ce87aba474834c655))
 
 
 ### Features

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -1,0 +1,16 @@
+const createPreset = require('conventional-changelog-conventionalcommits').default;
+
+module.exports = createPreset({
+  types: [
+    { type: 'feat', section: 'Features' },
+    { type: 'fix', section: 'Bug Fixes' },
+    { type: 'UX', section: 'Improvements' },
+    { type: 'perf', section: 'Performance Optimizations' },
+    { type: 'docs', section: 'Documentation Updates' },
+    { type: 'chore', section: 'Miscellaneous tasks' },
+    { type: 'CI', section: 'CI Changes' },
+    { type: 'revert', section: 'Reverts' },
+    { type: 'refactor', section: 'Internal Changes' },
+    { type: 'BREAKING', section: 'BREAKING CHANGES' },
+  ]
+});

--- a/changelog.config.ts
+++ b/changelog.config.ts
@@ -7,7 +7,8 @@ export default createPreset({
     { type: 'UX', section: 'Improvements' },
     { type: 'perf', section: 'Performance Optimizations' },
     { type: 'docs', section: 'Documentation Updates' },
-    { type: 'chore', section: 'Miscellaneous tasks' },
+    { type: 'chore', section: 'Miscellaneous/infrastructure tasks' },
+    { type: 'test', section: 'Test Coverage' }
     { type: 'CI', section: 'CI Changes' },
     { type: 'revert', section: 'Reverts' },
     { type: 'refactor', section: 'Internal Changes' },

--- a/changelog.config.ts
+++ b/changelog.config.ts
@@ -1,6 +1,6 @@
-const createPreset = require('conventional-changelog-conventionalcommits').default;
+import createPreset from 'conventional-changelog-conventionalcommits';
 
-module.exports = createPreset({
+export default createPreset({
   types: [
     { type: 'feat', section: 'Features' },
     { type: 'fix', section: 'Bug Fixes' },
@@ -11,6 +11,6 @@ module.exports = createPreset({
     { type: 'CI', section: 'CI Changes' },
     { type: 'revert', section: 'Reverts' },
     { type: 'refactor', section: 'Internal Changes' },
-    { type: 'BREAKING', section: 'BREAKING CHANGES' },
+    { type: 'BREAKING', section: 'BREAKING CHANGES' }
   ]
 });

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "devDependencies": {
     "prettier": "2.8.3",
     "@types/node": "20.12.0",
+    "conventional-changelog-cli": "^5.0.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
+    "tsx": "^4.22.3",
     "typescript": "5.3.3"
   }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,7 @@ TEMP_CHANGELOG=$(mktemp)
 # Since conventional-changelog automatically resolves the previous tag and generates the release notes
 # from that last tag up to HEAD under the name/version declared in package.json, we don't need any
 # temporary tagging or complex parsing hacks. It just works natively!
-npx --yes --package conventional-changelog-cli conventional-changelog --preset angular --release-count 1 > "$TEMP_CHANGELOG"
+NODE_OPTIONS="--import tsx" npx --no-install conventional-changelog --config changelog.config.ts --release-count 1 > "$TEMP_CHANGELOG"
 
 echo "--------------------------------------------------"
 cat "$TEMP_CHANGELOG"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Since the tag was manually pushed, GitHub automatically created a lightweight release/tag placeholder on GitHub because of the pushed tag (or because of some automatic UI
configuration/behavior). When `gh release create
"${{ env.HEAD_TAG }}"` ran, GitHub might have replied "Release already exists" (or did not overwrite the existing notes/placeholder because it was already created with the default commit message "chore: release v0.0.755").

To fix this and make it extremely reliable: if the release already exists (or gh release create fails or skips because it's already there), we fallback to gh release edit with:

````
gh release edit "${{ env.HEAD_TAG }}" --notes-file CHANGELOG_RELEASE.md
````

This guarantees that even if a placeholder is pre-created by GitHub because of the pushed tag, we overwrite and update its release notes with our newly generated conventional changelog block! Updated publish.yml to support this create || edit fallback.